### PR TITLE
use suggest properties instead of deprecated methods

### DIFF
--- a/application/helpers/menu_helper.php
+++ b/application/helpers/menu_helper.php
@@ -6,7 +6,7 @@ if ( ! function_exists('active_link_controller'))
     function active_link_controller($controller)
     {
         $CI    =& get_instance();
-        $class = $CI->router->fetch_class();
+        $class = $CI->router->class;
 
         return ($class == $controller) ? 'active' : NULL;
     }
@@ -18,7 +18,7 @@ if ( ! function_exists('active_link_function'))
     function active_link_function($controller)
     {
         $CI    =& get_instance();
-        $class = $CI->router->fetch_method();
+        $class = $CI->router->method;
 
         return ($class == $controller) ? 'active' : NULL;
     }


### PR DESCRIPTION
Both fetch_class() and fetch_method() are deprecated from CI_Router class since CI 3.0.x released, 
It was recommended to use public properties instead.

See: 
https://www.codeigniter.com/userguide3/installation/upgrade_300.html#uri-routing-methods-fetch-directory-fetch-class-fetch-method

https://github.com/domProjects/CI-AdminLTE/blob/425886df00dc59bd139f334b38b55abbf8f91fac/system/core/Router.php#L72

https://github.com/domProjects/CI-AdminLTE/blob/425886df00dc59bd139f334b38b55abbf8f91fac/system/core/Router.php#L79